### PR TITLE
Properly look up file by l10n parent

### DIFF
--- a/Classes/DataHandler/DataHandlerHook.php
+++ b/Classes/DataHandler/DataHandlerHook.php
@@ -65,9 +65,15 @@ class DataHandlerHook
         if ($table === 'sys_file_reference' && isset($fieldArray['sys_language_uid']) && (int)$fieldArray['sys_language_uid'] > 0) {
             /** @var QueryBuilder $queryBuilder */
             $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($table);
-            $parentFile = (int)$queryBuilder->select('uid_local')->from('sys_file_reference')->where(
-                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter((int)$fieldArray['uid_local'], \PDO::PARAM_INT))
-            )->execute()->fetchColumn();
+            $parentFile = (int)$queryBuilder
+                ->select('uid_local')
+                ->from('sys_file_reference')
+                ->where($queryBuilder->expr()->eq(
+                    'uid',
+                    $queryBuilder->createNamedParameter((int)$fieldArray['l10n_parent'], \PDO::PARAM_INT)
+                ))
+                ->execute()
+                ->fetchColumn();
             $fileVariantUid = $this->findLanguageVariantForLanguageAndParentFile((int)$fieldArray['sys_language_uid'], $parentFile);
             if ($fileVariantUid > 0) {
                 $fieldArray['uid_local'] = $fileVariantUid;


### PR DESCRIPTION
The previous lookup tried to find a sys_file_reference record using a sys_file UID which did not make sense. We now look up the sys_file UID by the translation parent (`l10n_parent`) of the sys_file_reference translation instead.