### PR TITLE
Update l10n labels from "lang" to "core"

### DIFF
--- a/Classes/Service/ResourcesService.php
+++ b/Classes/Service/ResourcesService.php
@@ -102,7 +102,10 @@ class ResourcesService
         $content = '';
         if ($file->isMissing()) {
             $content .= '<span class="label label-danger label-space-right">'
-                . htmlspecialchars(LocalizationUtility::translate('LLL:EXT:lang/Resources/Private/Language/locallang_core.xlf:warning.file_missing', 'lang'))
+                . htmlspecialchars(LocalizationUtility::translate(
+                    'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:warning.file_missing',
+                    'core'
+                ))
                 . '</span>';
         }
         if ($previewImage) {

--- a/Configuration/TCA/Overrides/sys_file.php
+++ b/Configuration/TCA/Overrides/sys_file.php
@@ -12,15 +12,15 @@ defined('TYPO3_MODE') or die();
 call_user_func(function () {
     $tempColumns = [
         'sys_language_uid' => [
-            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.language',
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'foreign_table' => 'sys_language',
                 'foreign_table_where' => 'ORDER BY sys_language.title',
                 'items' => [
-                    ['LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.default_value', 0],
-                    ['LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages', -1],
+                    ['LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.default_value', 0],
+                    ['LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages', -1],
                 ],
                 'default' => 0,
                 'fieldWizard' => [
@@ -32,7 +32,7 @@ call_user_func(function () {
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
-            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',


### PR DESCRIPTION
The fallback layer has been dropped with TYPO3v10.

See https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.3/Breaking-84680-RemovedUnusedLocallangFilesFromEXTlang.html