### PR TITLE
Drop support for TYPO3v9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,11 +52,11 @@
 	},
 	"require": {
 		"psr/http-message": "^1.0.0",
-		"typo3/cms-backend": "^9.5 || ^10.4",
-		"typo3/cms-core": "^9.5 || ^10.4",
-		"typo3/cms-extbase": "^9.5 || ^10.4",
-		"typo3/cms-fluid": "^9.5 || ^10.4",
-		"typo3/cms-install": "^9.5 || ^10.4"
+		"typo3/cms-backend": "^10.4",
+		"typo3/cms-core": "^10.4",
+		"typo3/cms-extbase": "^10.4",
+		"typo3/cms-fluid": "^10.4",
+		"typo3/cms-install": "^10.4"
 	},
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^2.12",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'category' => 'extension',
     'constraints' => [
         'depends' => [
-            'typo3' => '9.5.0-10.4.99'
+            'typo3' => '10.4.0-10.4.99'
         ],
         'conflicts' => [],
     ],


### PR DESCRIPTION
We will soon start supporting TYPO3v11 which is easier with only
TYPO3v10 support additionally.