### PR TITLE
Revive unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 # CGL Fixer
 .php_cs.cache
 
+# PHPUnit
+Build/.phpunit.result.cache
+
 # TYPO3
 /Build/Web
 /file_variants

--- a/Classes/DataHandler/DataHandlerHook.php
+++ b/Classes/DataHandler/DataHandlerHook.php
@@ -179,7 +179,7 @@ class DataHandlerHook
     protected function substNewWithId($id, DataHandler $pObj): int
     {
         if (is_string($id) && strpos($id, 'NEW') !== false) {
-            $id = $pObj->substNEWwithIDs[$id];
+            $id = $pObj->substNEWwithIDs[$id] ?? null;
         }
         if ($id === null) {
             $id = -1;

--- a/Tests/Unit/DataHandler/DataHandlerHookTest.php
+++ b/Tests/Unit/DataHandler/DataHandlerHookTest.php
@@ -25,8 +25,11 @@ namespace T3G\AgencyPack\FileVariants\Tests\Unit\DataHandler;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
-use T3G\AgencyPack\FileVariants\DataHandler\DataHandlerHook;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use T3G\AgencyPack\FileVariants\DataHandler\DataHandlerHook;
+use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Class DataHandlerHookTest
@@ -42,6 +45,11 @@ class DataHandlerHookTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionCode(1490476773);
+
+        $extensionConfiguration = $this->prophesize(ExtensionConfiguration::class);
+        $extensionConfiguration->get('file_variants')->willThrow(ExtensionConfigurationExtensionNotConfiguredException::class);
+        GeneralUtility::addInstance(ExtensionConfiguration::class, $extensionConfiguration->reveal());
+
         new DataHandlerHook();
     }
 
@@ -52,9 +60,8 @@ class DataHandlerHookTest extends TestCase
     {
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['file_variants'] = ['foo'];
         $subject = new DataHandlerHook();
-        /** @var DataHandler $dataHandler */
         $dataHandler = $this->prophesize(DataHandler::class);
-        $dataHandler->substNEWwithIDs = [];
+        $dataHandler->reveal()->substNEWwithIDs = [];
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionCode(1489332067);

--- a/Tests/Unit/DataHandler/DataHandlerHookTest.php
+++ b/Tests/Unit/DataHandler/DataHandlerHookTest.php
@@ -24,6 +24,7 @@ namespace T3G\AgencyPack\FileVariants\Tests\Unit\DataHandler;
  */
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use T3G\AgencyPack\FileVariants\DataHandler\DataHandlerHook;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 
@@ -32,6 +33,7 @@ use TYPO3\CMS\Core\DataHandling\DataHandler;
  */
 class DataHandlerHookTest extends TestCase
 {
+    use ProphecyTrait;
 
     /**
      * @test

--- a/Tests/Unit/Service/ResourcesServiceTest.php
+++ b/Tests/Unit/Service/ResourcesServiceTest.php
@@ -10,9 +10,11 @@
 namespace T3G\AgencyPack\FileVariants\Service;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class ResourcesServiceTest extends TestCase
 {
+    use ProphecyTrait;
 
     /**
      * @test

--- a/Tests/Unit/Service/ResourcesServiceTest.php
+++ b/Tests/Unit/Service/ResourcesServiceTest.php
@@ -11,6 +11,8 @@ namespace T3G\AgencyPack\FileVariants\Service;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use TYPO3\CMS\Core\Resource\ResourceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class ResourcesServiceTest extends TestCase
 {
@@ -26,8 +28,13 @@ class ResourcesServiceTest extends TestCase
 
         $config = [
             'variantsStorageUid' => 42,
+            'variantsFolder' => '/languageVariants',
         ];
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['file_variants'] = $config;
+
+        $resourceFactory = $this->prophesize(ResourceFactory::class);
+        $resourceFactory->getStorageObject(42)->willThrow(\InvalidArgumentException::class);
+        GeneralUtility::setSingletonInstance(ResourceFactory::class, $resourceFactory->reveal());
 
         $subject = new ResourcesService();
         $subject->prepareFileStorageEnvironment();

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,8 @@
 		"friendsofphp/php-cs-fixer": "^2.12",
 		"roave/security-advisories": "dev-master",
 		"typo3/testing-framework": "^6.0",
-		"phpspec/prophecy": "^1.19"
+		"phpspec/prophecy": "^1.19",
+		"phpspec/prophecy-phpunit": "^2.2"
 	},
 	"replace": {
 		"t3g/file_variants": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,8 @@
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^2.12",
 		"roave/security-advisories": "dev-master",
-		"typo3/testing-framework": "^6.0"
+		"typo3/testing-framework": "^6.0",
+		"phpspec/prophecy": "^1.19"
 	},
 	"replace": {
 		"t3g/file_variants": "self.version"


### PR DESCRIPTION
```
$ bin/phpunit -c Build/UnitTests.xml 
PHPUnit 9.6.17 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

...                                                                 3 / 3 (100%)

Time: 00:00.099, Memory: 34.01 MB

OK (3 tests, 6 assertions)
```