### PR TITLE
Streamline Composer scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,17 +35,17 @@
 		}
 	},
 	"scripts": {
-		"t3g:test:php:unit": [
+		"php:unit:test": [
 			"phpunit -c Build/UnitTests.xml --log-junit logs/phpunit.xml"
 		],
-		"t3g:test:php:functional": [
+		"php:functional:tests": [
 			"phpunit -c Build/FunctionalTests.xml --log-junit logs/phpunit.xml"
 		],
-		"t3g:test": [
-			"@t3g:test:php:unit",
-			"@t3g:test:php:functional"
+		"test": [
+			"@php:unit:test",
+			"@php:functional:tests"
 		],
-		"t3g:cgl": [
+		"php:style:fix": [
 			"php-cs-fixer fix --config Build/.php_cs.dist --format=junit > logs/php-cs-fixer.xml"
 		]
 	},


### PR DESCRIPTION
Drop the unnecessary prefix and have all commands follow this pattern:

    <topic>(:<subtopic>):<action>