### PR TITLE
Remove roave/security-advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
 		"friendsofphp/php-cs-fixer": "^3.0",
 		"phpspec/prophecy": "^1.19",
 		"phpspec/prophecy-phpunit": "^2.2",
-		"roave/security-advisories": "dev-master",
 		"typo3/testing-framework": "^6.0"
 	},
 	"replace": {


### PR DESCRIPTION
This is mostly useful for TYPO3 projects, not for TYPO3 extensions. Otherwise we cannot provide support for potentially insecure TYPO3 versions.