### PR TITLE
Restore upgrade wizard identifier

### DIFF
--- a/Classes/Updates/MetaDataRecordsUpdateWizard.php
+++ b/Classes/Updates/MetaDataRecordsUpdateWizard.php
@@ -20,6 +20,8 @@ use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
  */
 class MetaDataRecordsUpdateWizard implements UpgradeWizardInterface
 {
+    public const IDENTIFIER = 'T3G\AgencyPack\FileVariants\Updates\MetaDataRecordsUpdateWizard';
+
     /**
      * Return the identifier for this wizard
      * This should be the same string as used in the ext_localconf class registration
@@ -28,7 +30,7 @@ class MetaDataRecordsUpdateWizard implements UpgradeWizardInterface
      */
     public function getIdentifier(): string
     {
-        return self::class;
+        return self::IDENTIFIER;
     }
 
     /**

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -27,5 +27,5 @@ call_user_func(function () {
     ];
 
     // Upgrade Wizard
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][MetaDataRecordsUpdateWizard::class] = MetaDataRecordsUpdateWizard::class;
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][MetaDataRecordsUpdateWizard::IDENTIFIER] = MetaDataRecordsUpdateWizard::class;
 });


### PR DESCRIPTION
This identifier must never change since it can cause the wizard to be re-run and cause errors.

Regression in https://github.com/pagemachine/typo3-file-variants/pull/97