### PR TITLE
Register upgrade wizard via attribute

### DIFF
--- a/Classes/Updates/MetaDataRecordsUpdateWizard.php
+++ b/Classes/Updates/MetaDataRecordsUpdateWizard.php
@@ -7,6 +7,7 @@ use Pagemachine\FileVariants\Service\ResourcesService;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Install\Attribute\UpgradeWizard;
 use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
 use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 
@@ -18,21 +19,9 @@ use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
  *
  * Class MetaDataRecordsUpdateWizard
  */
+#[UpgradeWizard('T3G\AgencyPack\FileVariants\Updates\MetaDataRecordsUpdateWizard')]
 class MetaDataRecordsUpdateWizard implements UpgradeWizardInterface
 {
-    public const IDENTIFIER = 'T3G\AgencyPack\FileVariants\Updates\MetaDataRecordsUpdateWizard';
-
-    /**
-     * Return the identifier for this wizard
-     * This should be the same string as used in the ext_localconf class registration
-     *
-     * @return string
-     */
-    public function getIdentifier(): string
-    {
-        return self::IDENTIFIER;
-    }
-
     /**
      * Return the speaking name of this wizard
      *

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,7 +3,6 @@
 use Pagemachine\FileVariants\DataHandler\DataHandlerHook;
 use Pagemachine\FileVariants\FormEngine\FileVariantInfoElement;
 use Pagemachine\FileVariants\FormEngine\FieldWizard\FileVariantsOverviewWizard;
-use Pagemachine\FileVariants\Updates\MetaDataRecordsUpdateWizard;
 
 if (!defined('TYPO3')) {
     die('Access denied!');
@@ -25,7 +24,4 @@ call_user_func(function () {
         'priority' => 40,
         'class' => FileVariantsOverviewWizard::class,
     ];
-
-    // Upgrade Wizard
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][MetaDataRecordsUpdateWizard::IDENTIFIER] = MetaDataRecordsUpdateWizard::class;
 });


### PR DESCRIPTION
This ensures the given legacy identifier is used. Also the old registration is deprecated.

See https://docs.typo3.org/permalink/changelog:feature-99586-1673989775