### PR TITLE
Prevent update wizard from running again

### DIFF
--- a/Classes/Updates/MetaDataRecordsUpdateWizard.php
+++ b/Classes/Updates/MetaDataRecordsUpdateWizard.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pagemachine\FileVariants\Updates;
+namespace T3G\AgencyPack\FileVariants\Updates;
 
 
 use Pagemachine\FileVariants\Service\ResourcesService;
@@ -19,7 +19,7 @@ use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
  *
  * Class MetaDataRecordsUpdateWizard
  */
-#[UpgradeWizard('T3G\AgencyPack\FileVariants\Updates\MetaDataRecordsUpdateWizard')]
+#[UpgradeWizard(MetaDataRecordsUpdateWizard::class)]
 class MetaDataRecordsUpdateWizard implements UpgradeWizardInterface
 {
     /**

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -6,6 +6,10 @@ services:
 
   Pagemachine\FileVariants\:
     resource: '../Classes/*'
+    exclude: '../Classes/Updates/*'
+
+  T3G\AgencyPack\FileVariants\Updates\:
+    resource: '../Classes/Updates/*'
 
   Pagemachine\FileVariants\EventListener\BeforeFileDeletedEventListener:
     tags:

--- a/Tests/Functional/PublicFileStorage/UpgradeWizardTest.php
+++ b/Tests/Functional/PublicFileStorage/UpgradeWizardTest.php
@@ -4,7 +4,7 @@ namespace Pagemachine\FileVariants\Tests\Functional\PublicFileStorage;
 
 use PHPUnit\Framework\Attributes\Test;
 use Pagemachine\FileVariants\Tests\Functional\FunctionalTestCase;
-use Pagemachine\FileVariants\Updates\MetaDataRecordsUpdateWizard;
+use T3G\AgencyPack\FileVariants\Updates\MetaDataRecordsUpdateWizard;
 use TYPO3\CMS\Core\Core\Environment;
 
 /**

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"Pagemachine\\FileVariants\\": "Classes/"
+			"Pagemachine\\FileVariants\\": "Classes/",
+			"T3G\\AgencyPack\\FileVariants\\Updates\\": "Classes/Updates/"
 		}
 	},
 	"autoload-dev": {


### PR DESCRIPTION
TYPO3 stores update wizards in its registry by their class name instead of identifier. By renaming the wizard it was run again which must be avoided.

We fix this now by restoring the legacy class name.